### PR TITLE
Add Ubuntu Jammy (22.04)

### DIFF
--- a/build
+++ b/build
@@ -48,6 +48,7 @@ def main() -> NoReturn:
         f'git config --global user.email "asottile@umich.edu" && '
         f'apt-get update -qq && '
         f'mk-build-deps --install --remove --tool "apt-get --yes" debian/control && '  # noqa
+        f'rm -f *.buildinfo *.changes && '
         f'gbp buildpackage {gbp_args} --git-pristine-tar --git-debian-branch=ubuntu/{dist} {extra} && '  # noqa
         f'find .. -maxdepth 1 -type f | xargs --replace cp {{}} /dist'
     )

--- a/dockerfiles/Dockerfile.jammy
+++ b/dockerfiles/Dockerfile.jammy
@@ -1,0 +1,54 @@
+# Created with `./make-new-image --codename jammy ../python3.8/debian/control` DO NOT EDIT
+FROM ubuntu:jammy
+RUN : \
+    && apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+        -qq -y --no-install-recommends \
+        autoconf \
+        blt-dev \
+        build-essential:amd64 \
+        bzip2 \
+        debhelper \
+        devscripts \
+        dpkg-dev \
+        equivs \
+        git-buildpackage \
+        gnupg \
+        libbluetooth-dev \
+        libbz2-dev \
+        libdb-dev \
+        libexpat1-dev \
+        libffi-dev \
+        libgdbm-dev \
+        libgpm2 \
+        liblzma-dev \
+        libmpdec-dev \
+        libncurses-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl1.1 \
+        locales \
+        lsb-release \
+        mime-support \
+        net-tools \
+        netbase \
+        pristine-tar \
+        python3-sphinx \
+        python3:any \
+        quilt \
+        sharutils \
+        texinfo \
+        time \
+        tk-dev \
+        wget \
+        xauth \
+        xvfb \
+        zlib1g-dev \
+    # jammy only has libssl-dev for openssl 3.0, but it has both libssl1.1 and libssl3 for runtime.
+    # Only python 3.9 and above support openssl 3.0 (https://bugs.python.org/issue38820), so for any
+    # older python versions this is needed.
+    && wget http://mirrors.kernel.org/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1l-1ubuntu1_amd64.deb \
+    && dpkg -i libssl-dev_1.1.1l-1ubuntu1_amd64.deb \
+    && rm libssl-dev_1.1.1l-1ubuntu1_amd64.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/quick-test
+++ b/quick-test
@@ -11,6 +11,7 @@ inst() {{
 }}
 
 . /etc/lsb-release
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update -qq
 inst libpython{ver}-minimal
@@ -20,21 +21,24 @@ inst python{ver}-minimal
 inst python{ver}
 
 python{ver} -c 'import cmath, ssl'
-# distutils.__init__ and distutils.version should be in main lib package
-python{ver} -c 'import distutils; assert distutils.__file__'
-python{ver} -c 'import distutils.version'
 
 apt-get install -y --no-install-recommends ca-certificates
 if [ \
     "$DISTRIB_CODENAME" = bionic -a {ver} = '3.7' -o \
     "$DISTRIB_CODENAME" = bionic -a {ver} = '3.8' -o \
-    "$DISTRIB_CODENAME" = focal -a {ver} = '3.9' \
+    "$DISTRIB_CODENAME" = focal -a {ver} = '3.9' -o \
+    "$DISTRIB_CODENAME" = jammy -a {ver} = '3.9' -o \
+    "$DISTRIB_CODENAME" = jammy -a {ver} = '3.10' \
 ]; then
     apt-get install -y --no-install-recommends python3-distutils
 else
     inst python{ver}-lib2to3
     inst python{ver}-distutils
 fi
+
+# distutils.__init__ and distutils.version should be in main lib package
+python{ver} -c 'import distutils; assert distutils.__file__'
+python{ver} -c 'import distutils.version'
 
 # make sure get-pip.py works
 python{ver} -c '


### PR DESCRIPTION
I don't expect this to be merged until April (after the freeze), but this is what I did to get a jammy image and builds working so I wanted to actually contribute it back! I've got python3.7 and python3.8 PRs to follow this, but haven't tried the build on any other versions yet (and [3.9](https://packages.ubuntu.com/jammy/python3.9)/[3.10](https://packages.ubuntu.com/jammy/python3.10) are included in jammy already).

I'd love if `libssl1.1-dev` actually existed in jammy, but only [`libssl-dev`](https://packages.ubuntu.com/jammy/libssl-dev) does and it is on 3.0. From https://bugs.python.org/issue38820, python below 3.9 doesn't support OpenSSL 3.0, so installing the version from impish seems like the next best thing to do... Jammy does have [`libssl1.1`](https://packages.ubuntu.com/jammy/libssl1.1) and [`libssl3`](https://packages.ubuntu.com/jammy/libssl3) both available, so at runtime this shouldn't be an issue.

I needed to do the `rm -f *.buildinfo *.changes` to get around this error from gbp:
```
+ gbp buildpackage -us -uc --git-pristine-tar --git-debian-branch=ubuntu/jammy
gbp:error: You have uncommitted changes in your source tree:
gbp:error: On branch ubuntu/jammy
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        python3.8-build-deps_3.8.12-1+jammy1_amd64.buildinfo
        python3.8-build-deps_3.8.12-1+jammy1_amd64.changes

nothing added to commit but untracked files present (use "git add" to track)

gbp:error: Use --git-ignore-new to ignore.
```
(`--git-ignore-new` works too, but I figured this could still be a helpful check to keep for uncommitted/untracked files)

For the `quick-test` changes, I picked `3.9` and `3.10` for jammy since those are the versions included in https://packages.ubuntu.com/jammy/all/python3-distutils/filelist, and had to move the distutils check after installing it, otherwise it couldn't be found with the `python3.7` build (I'm surprised this worked in previous versions!)
```
+ python3.7 -c 'import distutils; assert distutils.__file__'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'distutils'
```