### PR TITLE
Open discussion regarding GPL-licensed libs (e.g. readline) in dependency tree

### DIFF
--- a/dockerfiles/Dockerfile.focal
+++ b/dockerfiles/Dockerfile.focal
@@ -24,7 +24,6 @@ RUN : \
         liblzma-dev \
         libmpdec-dev \
         libncurses-dev \
-        libreadline-dev \
         libsqlite3-dev \
         libssl-dev \
         locales \


### PR DESCRIPTION
Hello there,

doing some research we stumbled upon https://python-build-standalone.readthedocs.io

They have this statement:

"Most licenses are fairly permissive. Notable exceptions to this are GDBM and **readline**, which are **both licensed under GPL** Version 3."  (source: https://python-build-standalone.readthedocs.io/en/latest/running.html#licensing)

From what we can currently see deadsnakes python 3.10 does still link against libreadline. From what I can tell this seem to be some kind of GPL-infringement. At least 1999 some people (e.g. Richard Stallman) considered this to be the case: https://sourceware.org/legacy-ml/guile/1999-02/msg00235.html

Before we dig any deeper I would like to hear if someone at deadsnakes has already had some thoughts on that.
Is there something fundamental we oversee?

Best regards
   Manuel

